### PR TITLE
Return 'application/rss+xml' content type on /rss

### DIFF
--- a/camel.js
+++ b/camel.js
@@ -490,6 +490,7 @@ app.get('/', function (request, response) {
 });
 
 app.get('/rss', function (request, response) {
+    response.type('application/rss+xml');
     if (renderedRss['date'] == undefined || new Date().getTime() - renderedRss['date'].getTime() > 3600000) {
         var feed = new rss({
             title: siteMetadata['SiteTitle'],


### PR DESCRIPTION
Currently the content type of `/rss` is `text/html`, this makes sure the correct type is returned.
