### PR TITLE
Place notification of running server in callback

### DIFF
--- a/camel.js
+++ b/camel.js
@@ -643,5 +643,6 @@ app.get('/:slug', function (request, response) {
  ***************************************************/
 init();
 var port = Number(process.env.PORT || 5000);
-server.listen(port);
-console.log('Express server started on port %s', server.address().port);
+server.listen(port, function () {
+   console.log('Express server started on port %s', server.address().port); 
+});


### PR DESCRIPTION
`server.listen` is an asynchronous operation, and so the `console.log` may fire before the server is actually running. No longer.

[Relevant documentation.](http://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback)
