### PR TITLE
Everything up to and including a <script> tag was omitted from RSS

### DIFF
--- a/camel.js
+++ b/camel.js
@@ -515,7 +515,7 @@ app.get('/rss', function (request, response) {
                             // Offset the time because Heroku's servers are GMT, whereas these dates are EST/EDT.
                             date: new Date(article['metadata']['Date']).addHours(utcOffset),
                             url: externalFilenameForFile(article['file'], request),
-                            description: article['unwrappedBody'].replace(/[\s\S]*<script[\s\S]*<\/script>/gm, "")
+                            description: article['unwrappedBody'].replace(/<script[\s\S]*?<\/script>/gm, "")
                         });
                     }
                 });


### PR DESCRIPTION
The "[\s\S]*" in the regular expression was swallowing up the entire article up to the &lt;script> tag. Removing this allows the regex to remove just the tag itself. (I also changed the greedy "*" quantifier to the non-greedy "*?"; this will ensure that only one &lt;script> at a time is removed. Otherwise, if there were more than one script tag in an article then everything between the first and last &lt;script> would have been cut out.)
