### PR TITLE
Fixes broken rss meta tag in the head

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -3,7 +3,7 @@
         <title>@@SiteTitle@@ &mdash; @@Title@@</title>
         <link rel="stylesheet" type="text/css" href="/css/site.css">
         <link rel="alternate" type="application/rss+xml" title="@@SiteTitle@@" href="/rss" />
-        <link rel="alternate" type="application/rss+xml" title="@@SiteTitle@@ with link posts pointed to @@SiteTitle" href="/rss-alternate" />
+        <link rel="alternate" type="application/rss+xml" title="@@SiteTitle@@ with link posts pointed to @@SiteTitle@@" href="/rss-alternate" />
         <!-- Twitter Cards -->
         <meta property="twitter:card" content="summary" />
         <meta property="twitter:site" content="@site_twitter_username" />


### PR DESCRIPTION
Adds two @@ characters so that the /rss-alternate title in the head of every web page served by Camel doesn't say 

> [..] with link posts pointed to @@SiteTitle

The second SiteTitle variable is now properly replaced with the SiteTitle you specified in your defaultTags.html file