### PR TITLE
Add Domain Aware RSS Caching

### DIFF
--- a/camel.js
+++ b/camel.js
@@ -738,18 +738,18 @@ app.get('/rss', function (request, response) {
     }
     response.type('application/rss+xml');
 
-    if (typeof(renderedRss.date) === 'undefined' || new Date().getTime() - renderedRss.date.getTime() > 3600000) {
+    if (typeof(renderedRss[request.headers.host]) === 'undefined' || typeof(renderedRss[request.headers.host].date) === 'undefined' || new Date().getTime() - renderedRss[request.headers.host].date.getTime() > 3600000) {
 	    generateRss(request, '/rss', function (article) {
 			if (typeof(article.metadata.Link) !== 'undefined') {
 				return article.metadata.Link;
 			}
 			return externalFilenameForFile(article.file, request);
 		}, function (rss) {
-			renderedRss = rss;
-			response.status(200).send(renderedRss.rss);
+			renderedRss[request.headers.host] = rss;
+			response.status(200).send(renderedRss[request.headers.host].rss);
 		});
 	} else {
-		response.status(200).send(renderedRss.rss);
+		response.status(200).send(renderedRss[request.headers.host].rss);
 	}
 });
 

--- a/camel.js
+++ b/camel.js
@@ -733,23 +733,25 @@ app.get('/page/:page', function (request, response) {
 });
 
 app.get('/rss', function (request, response) {
+	var hostname = typeof(request) !== 'undefined' ? request.headers.host : 'global';
+
     if ('user-agent' in request.headers && request.headers['user-agent'].has('subscriber')) {
         console.log('RSS: ' + request.headers['user-agent']);
     }
     response.type('application/rss+xml');
 
-    if (typeof(renderedRss[request.headers.host]) === 'undefined' || typeof(renderedRss[request.headers.host].date) === 'undefined' || new Date().getTime() - renderedRss[request.headers.host].date.getTime() > 3600000) {
+    if (typeof(renderedRss[hostname]) === 'undefined' || typeof(renderedRss[hostname].date) === 'undefined' || new Date().getTime() - renderedRss[hostname].date.getTime() > 3600000) {
 	    generateRss(request, '/rss', function (article) {
 			if (typeof(article.metadata.Link) !== 'undefined') {
 				return article.metadata.Link;
 			}
 			return externalFilenameForFile(article.file, request);
 		}, function (rss) {
-			renderedRss[request.headers.host] = rss;
-			response.status(200).send(renderedRss[request.headers.host].rss);
+			renderedRss[hostname] = rss;
+			response.status(200).send(renderedRss[hostname].rss);
 		});
 	} else {
-		response.status(200).send(renderedRss[request.headers.host].rss);
+		response.status(200).send(renderedRss[hostname].rss);
 	}
 });
 


### PR DESCRIPTION
Closes #40

**Demo:**

```
camel on  bsc-domain-aware-rss-caching
➜ curl http://linode.liss.test/rss | grep linode
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1706    0  1706    0     0  41317      0 --:--:-- --:--:-- --:--:-- 47388
]]></description><link>http://www.vt.edu/</link><guid isPermaLink="false">http://linode.liss.test/2015/2/6/sample-link-post</guid><dc:creator><![CDATA[Your Name]]></dc:creator><pubDate>Fri, 06 Feb 2015 22:00:00 GMT</pubDate></item><item><title><![CDATA[Test Post]]></title><description><![CDATA[<p>This is a <em>test post</em> entitled “Test Post”.</p>
]]></description><link>http://linode.liss.test/2014/5/1/sample-post</link><guid isPermaLink="false">http://linode.liss.test/2014/5/1/sample-post</guid><dc:creator><![CDATA[Your Name]]></dc:creator><pubDate>Fri, 02 May 2014 02:50:00 GMT</pubDate></item></channel></rss>

camel on  bsc-domain-aware-rss-caching
➜ curl http://www.liss.test/rss | grep linode
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1697    0  1697    0     0   141k      0 --:--:-- --:--:-- --:--:--  276k
```